### PR TITLE
Create API abstract base class

### DIFF
--- a/pymfy/api/somfy_api.py
+++ b/pymfy/api/somfy_api.py
@@ -12,8 +12,56 @@ SOMFY_TOKEN = 'https://accounts.somfy.com/oauth/oauth/v2/token'
 SOMFY_REFRESH = 'https://accounts.somfy.com/oauth/oauth/v2/token'
 
 
-class SomfyApi:
-    __slots__ = '_oauth', 'client_id', 'client_secret'
+class AbstractSomfyApi:
+
+    base_url = BASE_URL
+
+    def get(self, path):
+        """Fetch a URL from the Somfy API."""
+        raise NotImplementedError
+
+    def post(self, path, *, json):
+        """Post data to the Somfy API."""
+        raise NotImplementedError
+
+    def get_sites(self) -> List[Site]:
+        r = self.get('/site')
+        r.raise_for_status()
+        return [Site(s) for s in r.json()]
+
+    def get_site(self, site_id: str) -> Site:
+        r = self.get('/site/' + site_id)
+        r.raise_for_status()
+        return Site(r.json())
+
+    def send_command(self, device_id: str,
+                     command: Union[Command, str]) -> str:
+        if isinstance(command, str):
+            command = Command(command)
+        r = self.post('/device/' + device_id + '/exec', json=command)
+        r.raise_for_status()
+        return r.json().get('job_id')
+
+    def get_devices(self, site_id: Optional[str] = None,
+                    category: Optional[Category] = None) -> List[Device]:
+        site_ids = [s.id for s in self.get_sites()] if site_id is None else [
+            site_id]
+        devices = []
+        for site_id in site_ids:
+            r = self.get('/site/' + site_id + "/device")
+            r.raise_for_status()
+            devices += [Device(d) for d in r.json() if
+                        category is None or category.value in Device(
+                            d).categories]
+        return devices
+
+    def get_device(self, device_id: str) -> Device:
+        r = self.get('/device/' + device_id)
+        r.raise_for_status()
+        return Device(r.json())
+
+
+class SomfyApi(AbstractSomfyApi):
 
     def __init__(self, client_id: str, client_secret: str,
                  redirect_uri: Optional[str] = None,
@@ -35,6 +83,14 @@ class SomfyApi:
                                     auto_refresh_url=SOMFY_REFRESH,
                                     token_updater=token_updater)
 
+    def get(self, path):
+        """Fetch a URL from the Somfy API."""
+        return self._oauth.get(self.base_url + path)
+
+    def post(self, path, *, json):
+        """Post data to the Somfy API."""
+        return self._oauth.post(self.base_url + path, json=json)
+
     def get_authorization_url(self, state: Optional[str] = None) -> Tuple[str, str]:
         return self._oauth.authorization_url(SOMFY_OAUTH, state)
 
@@ -52,40 +108,3 @@ class SomfyApi:
             authorization_response=authorization_response,
             code=code,
             client_secret=self.client_secret)
-
-    def get_sites(self) -> List[Site]:
-        r = self._oauth.get(BASE_URL + '/site')
-        r.raise_for_status()
-        return [Site(s) for s in r.json()]
-
-    def get_site(self, site_id: str) -> Site:
-        r = self._oauth.get(BASE_URL + '/site/' + site_id)
-        r.raise_for_status()
-        return Site(r.json())
-
-    def send_command(self, device_id: str,
-                     command: Union[Command, str]) -> str:
-        if isinstance(command, str):
-            command = Command(command)
-        r = self._oauth.post(BASE_URL + '/device/' + device_id + '/exec',
-                             json=command)
-        r.raise_for_status()
-        return r.json().get('job_id')
-
-    def get_devices(self, site_id: Optional[str] = None,
-                    category: Optional[Category] = None) -> List[Device]:
-        site_ids = [s.id for s in self.get_sites()] if site_id is None else [
-            site_id]
-        devices = []
-        for site_id in site_ids:
-            r = self._oauth.get(BASE_URL + '/site/' + site_id + "/device")
-            r.raise_for_status()
-            devices += [Device(d) for d in r.json() if
-                        category is None or category.value in Device(
-                            d).categories]
-        return devices
-
-    def get_device(self, device_id: str) -> Device:
-        r = self._oauth.get(BASE_URL + '/device/' + device_id)
-        r.raise_for_status()
-        return Device(r.json())

--- a/pymfy/api/somfy_api.py
+++ b/pymfy/api/somfy_api.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import Tuple, List, Optional, Union, Callable, Dict
 
 from requests_oauthlib import OAuth2Session
@@ -12,17 +13,17 @@ SOMFY_TOKEN = 'https://accounts.somfy.com/oauth/oauth/v2/token'
 SOMFY_REFRESH = 'https://accounts.somfy.com/oauth/oauth/v2/token'
 
 
-class AbstractSomfyApi:
+class AbstractSomfyApi(ABC):
 
     base_url = BASE_URL
 
+    @abstractmethod
     def get(self, path):
         """Fetch a URL from the Somfy API."""
-        raise NotImplementedError
 
+    @abstractmethod
     def post(self, path, *, json):
         """Post data to the Somfy API."""
-        raise NotImplementedError
 
     def get_sites(self) -> List[Site]:
         r = self.get('/site')


### PR DESCRIPTION
This refactors the SomfyAPI class to allow different implementations for sending `GET` and `POST` requests to the server. 

It's backwards compatible, all tests still pass.

Fixes #19