### PR TITLE
Add parent id support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 0.9.0
+* Add parent id support
 ### 0.8.0
 * Complete thermostat model
 ### 0.7.1

--- a/pymfy/api/model.py
+++ b/pymfy/api/model.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Union
 
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument, too-many-instance-attributes
 
 
 class Site:
@@ -12,7 +12,16 @@ class Site:
 
 
 class Device:
-    __slots__ = "id", "name", "type", "site_id", "states", "capabilities", "categories"
+    __slots__ = (
+        "id",
+        "name",
+        "type",
+        "site_id",
+        "states",
+        "capabilities",
+        "categories",
+        "parent_id",
+    )
 
     def __init__(
         self,
@@ -23,6 +32,7 @@ class Device:
         categories: List[str],
         states: List[Dict[str, Any]],
         capabilities: List[Dict[str, Any]],
+        parent_id: Optional[str] = None,
         name: Optional[str] = None,
         **kwargs: Any
     ):
@@ -33,6 +43,7 @@ class Device:
         self.categories = categories
         self.states = [State(**s) for s in states]
         self.capabilities = [Capability(**c) for c in capabilities]
+        self.parent_id = parent_id
 
 
 class State:


### PR DESCRIPTION
Read the parent_id attribute returned for a device. Will allow to link devices to an hub.