### PR TITLE
Add a workaround for low speed open/close

### DIFF
--- a/pymfy/api/devices/roller_shutter.py
+++ b/pymfy/api/devices/roller_shutter.py
@@ -16,12 +16,16 @@ class RollerShutter(SomfyDevice):
         self.send_command(command)
 
     def close(self, low_speed: Optional[bool] = False) -> None:
-        command = Command("position_low_speed", Parameter("position", 100) if low_speed else "close")
-        self.send_command(command)
+        if low_speed:
+            self.set_position(100, True)
+        else:
+            self.send_command(Command("close"))
 
     def open(self, low_speed: Optional[bool] = False) -> None:
-        command = Command("position_low_speed", Parameter("position", 0) if low_speed else "open")
-        self.send_command(command)
+        if low_speed:
+            self.set_position(0, True)
+        else:
+            self.send_command(Command("open"))
 
     def stop(self) -> None:
         self.send_command(Command("stop"))

--- a/pymfy/api/devices/roller_shutter.py
+++ b/pymfy/api/devices/roller_shutter.py
@@ -15,7 +15,7 @@ class RollerShutter(SomfyDevice):
         command = Command(command_name, Parameter("position", value))
         self.send_command(command)
 
-    def close(self, low_speed: Optional[int] = False) -> None:
+    def close(self, low_speed: Optional[bool] = False) -> None:
         command = Command("position_low_speed", Parameter("position", 100) if low_speed else "close")
         self.send_command(command)
 

--- a/pymfy/api/devices/roller_shutter.py
+++ b/pymfy/api/devices/roller_shutter.py
@@ -15,11 +15,13 @@ class RollerShutter(SomfyDevice):
         command = Command(command_name, Parameter("position", value))
         self.send_command(command)
 
-    def close(self) -> None:
-        self.send_command(Command("close"))
+    def close(self, low_speed: Optional[int] = False) -> None:
+        command = Command("position_low_speed", Parameter("position", 100) if low_speed else "close")
+        self.send_command(command)
 
-    def open(self) -> None:
-        self.send_command(Command("open"))
+    def open(self, low_speed: Optional[int] = False) -> None:
+        command = Command("position_low_speed", Parameter("position", 0) if low_speed else "open")
+        self.send_command(command)
 
     def stop(self) -> None:
         self.send_command(Command("stop"))

--- a/pymfy/api/devices/roller_shutter.py
+++ b/pymfy/api/devices/roller_shutter.py
@@ -19,7 +19,7 @@ class RollerShutter(SomfyDevice):
         command = Command("position_low_speed", Parameter("position", 100) if low_speed else "close")
         self.send_command(command)
 
-    def open(self, low_speed: Optional[int] = False) -> None:
+    def open(self, low_speed: Optional[bool] = False) -> None:
         command = Command("position_low_speed", Parameter("position", 0) if low_speed else "open")
         self.send_command(command)
 


### PR DESCRIPTION
This (re)uses position_low_speed for low speed close and open because the Somfy API currently does not provide this parameter on the rs100 on open/close commands and I would very much like to open/close them quietly via Home Assistant.

I tested the payload using the Somfy web API. Hopefully this workaround makes it possible with your library :)
Please let me know if this could be made prettier!